### PR TITLE
fix: バックアップ処理のエラーハンドリングを強化

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -29,12 +29,6 @@ export class BackupScheduler {
      * スケジュールされたバックアップ処理を実行します。
      */
     private async _runJob(): Promise<void> {
-        console.log(`定期バックアップ処理を開始します...`);
-        try {
-            await this.backupService.run();
-            console.log(`バックアップ処理が正常に完了しました。`);
-        } catch (error) {
-            console.error(`バックアップ処理中にエラーが発生しました。`, error);
-        }
+        await this.backupService.run();
     }
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -29,6 +29,12 @@ export class BackupScheduler {
      * スケジュールされたバックアップ処理を実行します。
      */
     private async _runJob(): Promise<void> {
-        await this.backupService.run();
+        try {
+            console.log("定期バックアップ処理を開始します");
+            await this.backupService.run();
+            console.log("定期バックアップ処理が正常に完了しました");
+        } catch (error) {
+            console.error("スケジュールされたバックアップジョブが失敗しました: ", error);
+        }
     }
 }

--- a/src/services/backup.service.ts
+++ b/src/services/backup.service.ts
@@ -13,18 +13,19 @@ export class BackupService {
 	 * バックアップ処理を実行する
 	 */
 	public async run(): Promise<void> {
-		console.log("バックアップ処理を開始します...");
-		let dumpFilePath: string | null = null;
-		try {
-			dumpFilePath = await this.dumper.dump();
-			await this.uploader.upload(dumpFilePath);
-			console.log("バックアップ処理が正常に完了しました。");
-		} catch (error) {
-			console.error("バックアップ処理中にエラーが発生しました:", error);
-		} finally {
-			if (dumpFilePath) {
-				await this.uploader.cleanup(dumpFilePath);
-			}
-		}
-	}
+        console.log("バックアップ処理を開始します...");
+        let dumpFilePath: string | null = null;
+        try {
+            dumpFilePath = await this.dumper.dump();
+            await this.uploader.upload(dumpFilePath);
+            console.log("バックアップ処理が正常に完了しました");
+        } catch (error) {
+            console.error("バックアップ処理中にエラーが発生しました: ", error);
+            throw error;
+        } finally {
+            if (dumpFilePath) {
+                await this.uploader.cleanup(dumpFilePath);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## fix: バックアップ処理のエラーハンドリングを強化
エラーを上位に再スローするようにしました。
~~元々上位処理でエラーハンドリングしていたものを削除してしまうコミットを出してしまいましたが、冷静に考えてサイレントエラーを引き起こす可能性があると判断し、少し改善しました。~~
***コミットした自分へ
しっかり考えてコミットしましょう***